### PR TITLE
Change `to_scipy_sparse_matrix` to match last nx release

### DIFF
--- a/code/tools.py
+++ b/code/tools.py
@@ -242,8 +242,8 @@ def build_sparse_B_from_A(A):
     d3, d3_T = np.array((), dtype='int64'), np.array((), dtype='int64')
     v, vT, v_T = np.array(()), np.array(()), np.array(())
     for l in range(L):
-        b = nx.to_scipy_sparse_matrix(A[l])
-        b_T = nx.to_scipy_sparse_matrix(A[l]).transpose()
+        b = nx.to_scipy_sparse_array(A[l])
+        b_T = nx.to_scipy_sparse_array(A[l]).transpose()
         rw.append(np.sum(b.multiply(b_T)) / np.sum(b))
         nz = b.nonzero()
         nz_T = b_T.nonzero()


### PR DESCRIPTION
Hi, I've changed the `tools.py` script to make it work with the last version of `nx`. Just for the record, this is the error I was getting:

`AttributeError: module 'networkx' has no attribute 'to_scipy_sparse_matrix'`

I'm working on making the repo work on a newer python version (say `3.9`).
